### PR TITLE
Disable scrolling while menu is open

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "devDependencies": {
     "@types/angular": "^1.5.19",
     "angular": "^1.5.8",
-    "rollup": "^0.40.2",
-    "rollup-plugin-cleanup": "^0.1.4",
+    "rollup": "^0.41.4",
+    "rollup-plugin-cleanup": "^1.0.0",
     "rollup-plugin-sourcemaps": "^0.4.1",
     "typescript": "^2.1.1"
   },

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -15,7 +15,7 @@ export class MenuManager {
 
     static openMenu(btn : HTMLButtonElement, mnu : HTMLMenuElement, focus : boolean = false) {
         if (this.transitionEndHandler !== null) {
-            this.transitionEndHandler!();
+            this.transitionEndHandler();
         }
 
         this.curButton = btn;

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -123,7 +123,7 @@ export class MenuManager {
         }
 
         let length = this.curMenu.children.length;
-        let mi = this.curMenu.children[this.focusCount % length] as HTMLElement;
+        let mi = this.curMenu.children[(this.focusCount || 0) % length] as HTMLElement;
 
         if (!mi.hasAttribute('disabled')) {
             mi.click();
@@ -268,7 +268,9 @@ export class MenuManager {
             e.preventDefault();
             e.stopPropagation();
 
-            MenuManager.focusCount--;
+            if (MenuManager.focusCount !== null) {
+                MenuManager.focusCount--;
+            }
             MenuManager.focusMenu();
         }
 
@@ -277,7 +279,9 @@ export class MenuManager {
             e.preventDefault();
             e.stopPropagation();
 
-            MenuManager.focusCount++;
+            if (MenuManager.focusCount !== null) {
+                MenuManager.focusCount++;
+            }
             MenuManager.focusMenu();
         }
 


### PR DESCRIPTION
Also update to fix syntax complaints from newer TypeScript.

I wonder if it's worth pulling the scrollBlocking code into its own module so that it can be reused by both ay-menu-button and ay-dialog 🤔 