### PR TITLE
Relax check to close any currently open menu when toggling a new one

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -107,7 +107,7 @@ export class MenuManager {
     static toggleMenu(btn : HTMLButtonElement) {
         let openMnu = this.curMenu;
 
-        if (this.isOpen && btn === this.curButton) {
+        if (this.isOpen) {
             this.closeMenu();
         }
 


### PR DESCRIPTION
This helps to ensure a prior menu will close if the `blur` event fails to fire.