### PR TITLE
Fix positioning bug in iOS Safari/WKWebView

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -158,6 +158,7 @@ export class MenuManager {
 
         let menu = this.curMenu!;
         let btn = this.curButton!;
+        let btnSize = btn.getBoundingClientRect();
 
         // Add the menu to the DOM for measuring
         menu.style.display = 'block';
@@ -177,7 +178,6 @@ export class MenuManager {
         }
 
         requestAnimationFrame(() => {
-            let btnSize = btn.getBoundingClientRect();
             let menuSize = menu.getBoundingClientRect();
             let wndHeight = window.innerHeight;
 


### PR DESCRIPTION
I believe this was caused by a [WebKit bug](https://bugs.webkit.org/show_bug.cgi?id=176053) that is triggered when we set the document body to position fixed and then try to measure element position on it.

Since the element position doesn't actually change before and after fixing the document, I believe it's safe for us to grab it before we adjust the document, so that we don't run into that bug.